### PR TITLE
Fix compile errors by adding missing cstdint includes

### DIFF
--- a/libs/p/include/p/klv.hpp
+++ b/libs/p/include/p/klv.hpp
@@ -18,6 +18,7 @@
 #define LIBP_KLV_HPP
 
 #include <p/endian.hpp>
+#include <cstdint>
 
 #define LIBP_PACKED __attribute__(( __packed__ ))
 

--- a/libs/q/include/q/block.hpp
+++ b/libs/q/include/q/block.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <cstdint>
 
 namespace q {
 

--- a/libs/q/include/q/stacktrace.hpp
+++ b/libs/q/include/q/stacktrace.hpp
@@ -20,6 +20,7 @@
 #include <iosfwd>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 namespace q {
 

--- a/libs/q/include/q/type_traits/core.hpp
+++ b/libs/q/include/q/type_traits/core.hpp
@@ -22,6 +22,7 @@
 #include <tuple>
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 namespace q {
 #define Q_FORWARD( value ) \

--- a/libs/q/src/detail/numeric.hpp
+++ b/libs/q/src/detail/numeric.hpp
@@ -18,6 +18,7 @@
 #define LIBQ_INTERNAL_NUMERIC_HPP
 
 #include <q/pp.hpp>
+#include <cstdint>
 
 #ifdef LIBQ_ON_WINDOWS
 #	include <intrin.h>

--- a/libs/q/src/stacktrace.cpp
+++ b/libs/q/src/stacktrace.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <cstring>
 #include <string>
+#include <cstdint>
 
 namespace q {
 


### PR DESCRIPTION
## Summary
- include `<cstdint>` where std::uintX_t are used

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: sleep_for not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e6d5e8a58832e9bfc25d6a5f7ad7a